### PR TITLE
Update power amplifier output to use 'pa-boost'

### DIFF
--- a/boards/catie/zest_core_fmlr-72/zest_core_fmlr-72.dts
+++ b/boards/catie/zest_core_fmlr-72/zest_core_fmlr-72.dts
@@ -108,7 +108,7 @@
 			    <&gpioc 5 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
 			    <&gpiob 11 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
 		spi-max-frequency = <DT_FREQ_M(3)>;
-		power-amplifier-output = "rfo";
+		power-amplifier-output = "pa-boost";
 	};
 };
 


### PR DESCRIPTION
The output for the power amplifier has been switched from "rfo" to "pa-boost", which may affect the radio transmission characteristics of the device.

* Changed `power-amplifier-output` property from `"rfo"` to `"pa-boost"`